### PR TITLE
Add Python binding and basic tests

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -16,7 +16,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools
-        pip install -e .
-        pip install pytest
+        pip install -e .[test]
     - name: Run tests
       run: pytest -q

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,23 @@
+name: Python package
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install cffi pytest
+    - name: Build extension
+      run: python setup.py build
+    - name: Run tests
+      run: pytest

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -15,9 +15,8 @@ jobs:
         python-version: '3.x'
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install cffi pytest
-    - name: Build extension
-      run: python setup.py build
+        python -m pip install --upgrade pip setuptools
+        pip install -e .
+        pip install pytest
     - name: Run tests
-      run: pytest
+      run: pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist/
 *.egg-info/
 *.pyc
 *.pyd
+python/obuparse/_obulib.*
 
 # IDE
 .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Build artifacts
+*.o
+*.so
+*.a
+*.dll
+*.dylib
+*.exe
+
+# Python artifacts
+__pycache__/
+build/
+dist/
+*.egg-info/
+*.pyc
+*.pyd
+
+# IDE
+.vscode/
+
+# Generated files
+/obudump
+

--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,5 @@ htmlcov/
 
 # Generated files
 /obudump
+tools/obudump
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,18 @@ dist/
 
 # IDE
 .vscode/
+.idea/
+
+# Virtual environments
+.env/
+.venv/
+venv/
+env/
+
+# Test and coverage artifacts
+.pytest_cache/
+.coverage
+htmlcov/
 
 # Generated files
 /obudump

--- a/README.md
+++ b/README.md
@@ -59,12 +59,13 @@ Python Package
 
  A Python wrapper is provided using `cffi`. Build and install it in
  editable mode so the extension is compiled and the CLI is available.
- The tests expect the extension to be installed, so make sure to
-install before running them:
+ The tests expect the extension to be installed. Install in editable
+ mode with the test extras so both the extension and test dependencies
+ are built:
 
 
 ```bash
-pip install -e .
+pip install -e .[test]
 ```
 
 The build process now compiles both the CFFI extension and the native

--- a/README.md
+++ b/README.md
@@ -57,19 +57,24 @@ an IVF file into JSON, called `dumpobu`.
 Python Package
 --------------
 
-A Python wrapper is provided using `cffi`. Build and install it in
-editable mode so the extension is compiled and the CLI is available.
-The tests expect the extension to be installed, so make sure to
+ A Python wrapper is provided using `cffi`. Build and install it in
+ editable mode so the extension is compiled and the CLI is available.
+ The tests expect the extension to be installed, so make sure to
 install before running them:
+
 
 ```bash
 pip install -e .
 ```
 
-This installs the `obuparse` module and an `obudump` command-line application
-implemented in Python. The CLI can parse IVF files and display basic information
-about contained OBUs. If you wish to build the original C version of
-`obudump`, run:
+The build process compiles the CFFI extension automatically, so you do not need
+to run `make` unless you specifically want the standalone C library or the
+native `obudump` binary.
+
+ This installs the `obuparse` module and an `obudump` command-line application
+ implemented in Python. The CLI can parse IVF files and display basic
+ information about contained OBUs. If you wish to build the original C
+ version of `obudump`, run:
 
 ```bash
 make tools

--- a/README.md
+++ b/README.md
@@ -57,17 +57,23 @@ an IVF file into JSON, called `dumpobu`.
 Python Package
 --------------
 
-A Python wrapper is provided using `cffi`. Install it with:
+A Python wrapper is provided using `cffi`. Build and install it in
+editable mode so the extension is compiled and the CLI is available:
 
 ```bash
-pip install .
+pip install -e .
 ```
 
-This installs the `obuparse` module and a compatible `obudump` command line
-application implemented in Python. The CLI can parse IVF files and display basic
-information about contained OBUs.
+This installs the `obuparse` module and an `obudump` command-line application
+implemented in Python. The CLI can parse IVF files and display basic information
+about contained OBUs. If you wish to build the original C version of
+`obudump`, run:
 
-Running tests:
+```bash
+make tools
+```
+
+Running tests (after installation):
 
 ```bash
 pytest

--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ install before running them:
 pip install -e .
 ```
 
-The build process compiles the CFFI extension automatically, so you do not need
-to run `make` unless you specifically want the standalone C library or the
-native `obudump` binary.
+The build process now compiles both the CFFI extension and the native
+`obudump` tool automatically. No manual `make` step is required when
+installing via `pip`.
 
- This installs the `obuparse` module and an `obudump` command-line application
- implemented in Python. The CLI can parse IVF files and display basic
- information about contained OBUs. If you wish to build the original C
- version of `obudump`, run:
+ This installs the `obuparse` module, a Python-based `obudump` command-line
+ application, and the native `obudump` binary. The CLI can parse IVF files and
+ display basic information about contained OBUs. The Makefile is still
+ available should you wish to rebuild the tools manually:
 
 ```bash
 make tools

--- a/README.md
+++ b/README.md
@@ -53,3 +53,22 @@ Tools
 
 The `tools` directory contains a simple tool to parse and serialize OBUs from
 an IVF file into JSON, called `dumpobu`.
+
+Python Package
+--------------
+
+A Python wrapper is provided using `cffi`. Install it with:
+
+```bash
+pip install .
+```
+
+This installs the `obuparse` module and a compatible `obudump` command line
+application implemented in Python. The CLI can parse IVF files and display basic
+information about contained OBUs.
+
+Running tests:
+
+```bash
+pytest
+```

--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ Python Package
 --------------
 
 A Python wrapper is provided using `cffi`. Build and install it in
-editable mode so the extension is compiled and the CLI is available:
+editable mode so the extension is compiled and the CLI is available.
+The tests expect the extension to be installed, so make sure to
+install before running them:
 
 ```bash
 pip install -e .
@@ -78,3 +80,4 @@ Running tests (after installation):
 ```bash
 pytest
 ```
+

--- a/README.md
+++ b/README.md
@@ -86,3 +86,30 @@ Running tests (after installation):
 pytest
 ```
 
+Examples
+--------
+
+Using the Python bindings directly:
+
+```python
+>>> from obuparse import ffi, lib
+>>> data = bytes([0x12, 0x00])
+>>> err_buf = ffi.new('char[1024]')
+>>> err = ffi.new('OBPError *', {'error': err_buf, 'size': 1024})
+>>> obu_type = ffi.new('OBPOBUType *')
+>>> offset = ffi.new('ptrdiff_t *')
+>>> obu_size = ffi.new('size_t *')
+>>> temporal_id = ffi.new('int *')
+>>> spatial_id = ffi.new('int *')
+>>> lib.obp_get_next_obu(data, len(data), obu_type, offset, obu_size,
+...                      temporal_id, spatial_id, err)
+0
+```
+
+Running the command-line tool to inspect an IVF file:
+
+```bash
+$ obudump -v sample.ivf
+{'obu_type': 2, 'offset': 2, 'obu_size': 0, 'temporal_id': 0, 'spatial_id': 0}
+```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ description = "A Python wrapper for the obuparse AV1 OBU parsing library."
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.7"
+dependencies = ["cffi>=1.0"]
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: ISC License (ISCL)",
@@ -27,4 +28,7 @@ fallback_version = "0.1.0"
 [tool.setuptools.packages.find]
 where = ["python"]
 include = ["obuparse*", "pyobuparse*"]
+
+[project.optional-dependencies]
+test = ["pytest", "cffi>=1.0"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,30 @@
 [build-system]
-requires = ["setuptools", "cffi>=1.0"]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4", "cffi>=1.0"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "obuparse"
+dynamic = ["version"]
+description = "A Python wrapper for the obuparse AV1 OBU parsing library."
+readme = "README.md"
+license = { file = "LICENSE" }
+requires-python = ">=3.7"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: ISC License (ISCL)",
+    "Operating System :: OS Independent",
+]
+
+[project.urls]
+Homepage = "https://github.com/google/pyobuparse"
+Repository = "https://github.com/google/pyobuparse"
+
+[tool.setuptools_scm]
+version_scheme = "guess-next-dev"
+local_scheme = "no-local-version"
+fallback_version = "0.1.0"
+
+[tool.setuptools.packages.find]
+where = ["python"]
+include = ["obuparse*", "pyobuparse*"]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "cffi>=1.0"]
+build-backend = "setuptools.build_meta"

--- a/python/ffi_builder.py
+++ b/python/ffi_builder.py
@@ -1,0 +1,25 @@
+from cffi import FFI
+import os
+
+ffibuilder = FFI()
+
+header_path = os.path.join(os.path.dirname(__file__), '..', 'obuparse.h')
+with open(header_path) as f:
+    lines = []
+    for line in f:
+        if line.startswith('#'):
+            continue
+        lines.append(line)
+    header = ''.join(lines)
+
+ffibuilder.cdef(header)
+
+ffibuilder.set_source(
+    'obuparse._obulib',
+    '#include "obuparse.h"',
+    sources=[os.path.join(os.path.dirname(__file__), '..', 'obuparse.c')],
+    include_dirs=[os.path.join(os.path.dirname(__file__), '..')],
+)
+
+if __name__ == '__main__':
+    ffibuilder.compile(verbose=True)

--- a/python/obuparse/__init__.py
+++ b/python/obuparse/__init__.py
@@ -1,0 +1,6 @@
+from . import _obulib
+
+ffi = _obulib.ffi
+lib = _obulib.lib
+
+__all__ = ["ffi", "lib"]

--- a/python/obuparse/cli.py
+++ b/python/obuparse/cli.py
@@ -1,0 +1,59 @@
+import argparse
+from . import ffi, lib
+
+
+def parse_ivf(path, verbose=False):
+    with open(path, 'rb') as f:
+        f.seek(32)  # skip IVF header
+        packet_number = 0
+        while True:
+            frame_header = f.read(12)
+            if len(frame_header) < 12:
+                break
+            packet_size = int.from_bytes(frame_header[0:4], 'little')
+            packet = f.read(packet_size)
+            if len(packet) < packet_size:
+                raise IOError('Truncated packet')
+            packet_pos = 0
+            while packet_pos < packet_size:
+                err_buf = ffi.new('char[1024]')
+                err = ffi.new('OBPError *', {'error': err_buf, 'size': 1024})
+                obu_type = ffi.new('OBPOBUType *')
+                offset = ffi.new('ptrdiff_t *')
+                obu_size = ffi.new('size_t *')
+                temporal_id = ffi.new('int *')
+                spatial_id = ffi.new('int *')
+                ret = lib.obp_get_next_obu(
+                    ffi.from_buffer(packet, writable=False)[packet_pos:],
+                    packet_size - packet_pos,
+                    obu_type,
+                    offset,
+                    obu_size,
+                    temporal_id,
+                    spatial_id,
+                    err,
+                )
+                if ret != 0:
+                    raise RuntimeError(ffi.string(err.error).decode())
+                if verbose:
+                    print({
+                        'obu_type': int(obu_type[0]),
+                        'offset': int(offset[0]),
+                        'obu_size': int(obu_size[0]),
+                        'temporal_id': int(temporal_id[0]),
+                        'spatial_id': int(spatial_id[0]),
+                    })
+                packet_pos += obu_size[0] + offset[0]
+            packet_number += 1
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description='Dump OBUs from an IVF file')
+    parser.add_argument('input', help='Input IVF file')
+    parser.add_argument('-v', '--verbose', action='store_true', help='Verbose output')
+    args = parser.parse_args(argv)
+    parse_ivf(args.input, args.verbose)
+
+
+if __name__ == '__main__':
+    main()

--- a/python/obuparse/cli.py
+++ b/python/obuparse/cli.py
@@ -24,7 +24,9 @@ def parse_ivf(path, verbose=False):
                 temporal_id = ffi.new('int *')
                 spatial_id = ffi.new('int *')
                 ret = lib.obp_get_next_obu(
-                    ffi.from_buffer(packet, writable=False)[packet_pos:],
+                    ffi.from_buffer(packet, require_writable=False)[
+                        packet_pos:packet_size
+                    ],
                     packet_size - packet_pos,
                     obu_type,
                     offset,

--- a/python/pyobuparse/__init__.py
+++ b/python/pyobuparse/__init__.py
@@ -1,0 +1,3 @@
+from obuparse import ffi, lib
+
+__all__ = ["ffi", "lib"]

--- a/setup.py
+++ b/setup.py
@@ -1,28 +1,41 @@
 from setuptools import setup
 from setuptools.command.build_ext import build_ext
+from distutils.ccompiler import new_compiler
+from distutils.sysconfig import customize_compiler
+import os
 import subprocess
 import sys
 
 
 class BuildExt(build_ext):
-    """Build CFFI extension and native tools."""
+    """Build CFFI extension and the native obudump tool."""
 
     def run(self):
         super().run()
-        try:
-            subprocess.check_call(["make", "tools"])
-        except Exception as exc:
-            print("warning: failed to build native tools:", exc, file=sys.stderr)
+        self.build_obudump()
+
+    def build_obudump(self):
+        compiler = new_compiler()
+        customize_compiler(compiler)
+        sources = [
+            os.path.join("tools", "obudump.c"),
+            os.path.join("tools", "json.c"),
+            "obuparse.c",
+        ]
+        objects = compiler.compile(sources, output_dir=self.build_temp, include_dirs=[".", "tools"])
+        exe_name = os.path.join(self.build_lib, "obudump")
+        compiler.link_executable(objects, exe_name)
+        self.distribution.data_files = self.distribution.data_files or []
+        self.distribution.data_files.append(("bin", [exe_name]))
 
 setup(
-    name='obuparse',
-    version='0.1.0',
-    package_dir={'': 'python'},
-    packages=['obuparse', 'pyobuparse'],
-    cffi_modules=['python/ffi_builder.py:ffibuilder'],
-    setup_requires=['cffi>=1.0'],
-    install_requires=['cffi>=1.0'],
-    entry_points={'console_scripts': ['obudump=obuparse.cli:main']},
-    data_files=[('bin', ['tools/obudump'])],
-    cmdclass={'build_ext': BuildExt},
+    name="obuparse",
+    use_scm_version=True,
+    package_dir={"": "python"},
+    packages=["obuparse", "pyobuparse"],
+    cffi_modules=["python/ffi_builder.py:ffibuilder"],
+    setup_requires=["cffi>=1.0", "setuptools_scm"],
+    install_requires=["cffi>=1.0"],
+    entry_points={"console_scripts": ["obudump=obuparse.cli:main"]},
+    cmdclass={"build_ext": BuildExt},
 )

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,28 @@
 from setuptools import setup
+from setuptools.command.build_ext import build_ext
+import subprocess
+import sys
+
+
+class BuildExt(build_ext):
+    """Build CFFI extension and native tools."""
+
+    def run(self):
+        super().run()
+        try:
+            subprocess.check_call(["make", "tools"])
+        except Exception as exc:
+            print("warning: failed to build native tools:", exc, file=sys.stderr)
 
 setup(
     name='obuparse',
     version='0.1.0',
     package_dir={'': 'python'},
-    packages=['obuparse'],
+    packages=['obuparse', 'pyobuparse'],
     cffi_modules=['python/ffi_builder.py:ffibuilder'],
     setup_requires=['cffi>=1.0'],
     install_requires=['cffi>=1.0'],
     entry_points={'console_scripts': ['obudump=obuparse.cli:main']},
+    data_files=[('bin', ['tools/obudump'])],
+    cmdclass={'build_ext': BuildExt},
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup
+
+setup(
+    name='obuparse',
+    version='0.1.0',
+    package_dir={'': 'python'},
+    packages=['obuparse'],
+    cffi_modules=['python/ffi_builder.py:ffibuilder'],
+    setup_requires=['cffi>=1.0'],
+    install_requires=['cffi>=1.0'],
+    entry_points={'console_scripts': ['obudump=obuparse.cli:main']},
+)

--- a/tests/test_obuparse.py
+++ b/tests/test_obuparse.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import subprocess
 import pytest
 
 ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
@@ -15,7 +16,6 @@ try:  # prefer installed package
     import pyobuparse
 except Exception:
     # build the CFFI extension in-place if missing
-    import subprocess
     subprocess.check_call(
         [sys.executable, "ffi_builder.py"], cwd=os.path.join(ROOT_DIR, "python")
     )
@@ -51,3 +51,33 @@ def test_get_next_obu_temporal_delimiter():
     assert offset[0] == 2
     assert obu_size[0] == 0
     assert pyobuparse.lib is obuparse.lib
+
+
+def _write_minimal_ivf(path):
+    header = bytearray()
+    header.extend(b'DKIF')
+    header.extend((0).to_bytes(2, 'little'))
+    header.extend((32).to_bytes(2, 'little'))
+    header.extend(b'AV01')
+    header.extend((0).to_bytes(2, 'little'))
+    header.extend((0).to_bytes(2, 'little'))
+    header.extend((30).to_bytes(4, 'little'))
+    header.extend((1).to_bytes(4, 'little'))
+    header.extend((1).to_bytes(4, 'little'))
+    header.extend((0).to_bytes(4, 'little'))
+    frame = bytes([0x12, 0x00])
+    frame_header = len(frame).to_bytes(4, 'little') + (0).to_bytes(8, 'little')
+    with open(path, 'wb') as f:
+        f.write(header)
+        f.write(frame_header)
+        f.write(frame)
+
+
+def test_cli_parses_ivf(tmp_path):
+    ivf = tmp_path / 'sample.ivf'
+    _write_minimal_ivf(ivf)
+    out = subprocess.check_output(
+        [sys.executable, '-m', 'obuparse.cli', '-v', str(ivf)],
+        text=True,
+    )
+    assert "'obu_type': 2" in out

--- a/tests/test_obuparse.py
+++ b/tests/test_obuparse.py
@@ -1,0 +1,26 @@
+import obuparse
+
+# Test parsing an OBU header for temporal delimiter (size 0)
+def test_get_next_obu_temporal_delimiter():
+    data = bytes([0x12, 0x00])  # OBU type 2 with size field 0
+    err_buf = obuparse.ffi.new('char[1024]')
+    err = obuparse.ffi.new('OBPError *', {'error': err_buf, 'size': 1024})
+    obu_type = obuparse.ffi.new('OBPOBUType *')
+    offset = obuparse.ffi.new('ptrdiff_t *')
+    obu_size = obuparse.ffi.new('size_t *')
+    temporal_id = obuparse.ffi.new('int *')
+    spatial_id = obuparse.ffi.new('int *')
+    ret = obuparse.lib.obp_get_next_obu(
+        data,
+        len(data),
+        obu_type,
+        offset,
+        obu_size,
+        temporal_id,
+        spatial_id,
+        err,
+    )
+    assert ret == 0
+    assert obu_type[0] == 2
+    assert offset[0] == 2
+    assert obu_size[0] == 0

--- a/tests/test_obuparse.py
+++ b/tests/test_obuparse.py
@@ -1,15 +1,13 @@
 import os
 import sys
 import subprocess
-import pytest
 
 ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
 sys.path.insert(0, os.path.join(ROOT_DIR, "python"))
 
-try:
-    import cffi  # noqa: F401
-except ImportError:
-    raise RuntimeError("cffi must be installed to build the Python extension")
+import pytest
+
+cffi = pytest.importorskip("cffi")
 
 try:  # prefer installed package
     import obuparse

--- a/tests/test_obuparse.py
+++ b/tests/test_obuparse.py
@@ -1,4 +1,20 @@
-import obuparse
+import os
+import sys
+
+ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(ROOT_DIR, "python"))
+
+try:  # prefer installed package
+    import obuparse
+except Exception:
+    # build the CFFI extension in-place if missing
+    import subprocess
+    subprocess.check_call(
+        [sys.executable, "ffi_builder.py"], cwd=os.path.join(ROOT_DIR, "python")
+    )
+    if 'obuparse' in sys.modules:
+        del sys.modules['obuparse']
+    import obuparse
 
 # Test parsing an OBU header for temporal delimiter (size 0)
 def test_get_next_obu_temporal_delimiter():

--- a/tests/test_obuparse.py
+++ b/tests/test_obuparse.py
@@ -12,6 +12,7 @@ except ImportError:
 
 try:  # prefer installed package
     import obuparse
+    import pyobuparse
 except Exception:
     # build the CFFI extension in-place if missing
     import subprocess
@@ -21,6 +22,9 @@ except Exception:
     if 'obuparse' in sys.modules:
         del sys.modules['obuparse']
     import obuparse
+    if 'pyobuparse' in sys.modules:
+        del sys.modules['pyobuparse']
+    import pyobuparse
 
 # Test parsing an OBU header for temporal delimiter (size 0)
 def test_get_next_obu_temporal_delimiter():
@@ -46,3 +50,4 @@ def test_get_next_obu_temporal_delimiter():
     assert obu_type[0] == 2
     assert offset[0] == 2
     assert obu_size[0] == 0
+    assert pyobuparse.lib is obuparse.lib

--- a/tests/test_obuparse.py
+++ b/tests/test_obuparse.py
@@ -5,7 +5,10 @@ import pytest
 ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
 sys.path.insert(0, os.path.join(ROOT_DIR, "python"))
 
-pytest.importorskip("cffi")
+try:
+    import cffi  # noqa: F401
+except ImportError:
+    raise RuntimeError("cffi must be installed to build the Python extension")
 
 try:  # prefer installed package
     import obuparse

--- a/tests/test_obuparse.py
+++ b/tests/test_obuparse.py
@@ -1,8 +1,11 @@
 import os
 import sys
+import pytest
 
 ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
 sys.path.insert(0, os.path.join(ROOT_DIR, "python"))
+
+pytest.importorskip("cffi")
 
 try:  # prefer installed package
     import obuparse


### PR DESCRIPTION
## Summary
- ignore build and Python artifacts
- provide CFFI-based Python bindings in `obuparse` package
- add command line interface wrapping OBU header parser
- document Python usage in README
- add GitHub Actions workflow
- include simple pytest

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68459817c32c8327acbf3781a3aacece